### PR TITLE
Update the views to show the upload and network status whether or not there are more activities

### DIFF
--- a/Sources/BridgeClientUI/SingleStudy/Views/TodayFinishedView.swift
+++ b/Sources/BridgeClientUI/SingleStudy/Views/TodayFinishedView.swift
@@ -5,88 +5,10 @@ import SwiftUI
 import BridgeClientExtension
 import SharedMobileUI
 
-/// A protocol that allows for using a different backing view model (or subclass) to show a view when there
-/// are no more assessments *currently* available to the participant.
-/// - See Also: ``GenericTodayWrapperView``
-public protocol TodayFinishedViewProtocol : View {
-    init()
-}
-
 /// Wrapped `UploadingMessageView` for use with MobileToolboxApp or other apps that do not require
 /// subclassing the app manager or today timeline view model because EnvironmentObjects must be final.
-struct TodayFinishedView : View, TodayFinishedViewProtocol {
-    @EnvironmentObject private var bridgeManager: SingleStudyAppManager
-    @EnvironmentObject private var viewModel: TodayTimelineViewModel
-    
-    var body: some View {
-        UploadingMessageView(isUploading: $bridgeManager.isUploading,
-                             networkStatus: $bridgeManager.networkStatus,
-                             isNextSessionSoon: viewModel.isNextSessionSoon)
-    }
-}
+struct TodayFinishedView : View {
 
-/// A general purpose implementation of the header view when there are no assessments currently available
-/// that does not directly tie to the backing view models.
-struct UploadingMessageView : View {
-    @Binding var isUploading: Bool
-    @Binding var networkStatus: NetworkStatus
-    let isNextSessionSoon: Bool
-    
-    var body: some View {
-        ZStack {
-            uploadingView()
-                .opacity(isUploading ? 1 : 0)
-            TodayUpToDateView()
-                .opacity(isUploading ? 0 : 1)
-        }
-        .frame(maxWidth: .infinity, alignment: .center)
-    }
-    
-    @ViewBuilder
-    func uploadingView() -> some View {
-        VStack(alignment: .center, spacing: 24) {
-            if networkStatus.contains(.notConnected) {
-                Image(systemName: "wifi.exclamationmark")
-                    .scaleEffect(x: 1.5, y: 1.5, anchor: .center)
-                    .foregroundColor(.errorRed)
-            } else {
-                progressSpinner()
-            }
-            uploadingMessageText()
-                .font(.italicLatoFont(22))
-        }
-        .padding()
-    }
-    
-    @ViewBuilder
-    func progressSpinner() -> some View {
-        if #available(iOS 15.0, *) {
-            ProgressView()
-                .tint(.accentColor)
-                .scaleEffect(x: 1.5, y: 1.5, anchor: .center)
-        } else {
-            ProgressView()
-        }
-    }
-    
-    @ViewBuilder
-    func uploadingMessageText() -> some View {
-        switch networkStatus {
-        case .cellularDenied:
-            Text("Connect to WiFi or turn on cellular data in your phone's \"Settings\" to allow the app to upload your results.", bundle: .module)
-        case .notConnected:
-            Text("Please connect to the internet to upload your results.", bundle: .module)
-        default:
-            if isNextSessionSoon {
-                Text("Your results are uploading...", bundle: .module)
-            } else {
-                Text("Your results are uploading. Please wait to close the app.", bundle: .module)
-            }
-        }
-    }
-}
-
-struct TodayUpToDateView : View, TodayFinishedViewProtocol {
     var body: some View {
         ZStack {
             Image(decorative: "available_complete", bundle: .module)
@@ -98,33 +20,6 @@ struct TodayUpToDateView : View, TodayFinishedViewProtocol {
     }
 }
 
-// Used to allow previewing the UploadingMessageView.
-fileprivate struct PreviewAllTodayFinished : View {
-    @State var isUploading: Bool = true
-    @State var networkStatus: NetworkStatus = .notConnected
-    @State var isNextSessionSoon: Bool = true
-    
-    var body: some View {
-        VStack {
-            UploadingMessageView(isUploading: $isUploading, networkStatus: $networkStatus, isNextSessionSoon: isNextSessionSoon)
-            Spacer()
-            Form {
-                Toggle("isUploading", isOn: $isUploading)
-                Toggle("isNextSessionSoon", isOn: $isNextSessionSoon)
-                Picker("Network Connection", selection: $networkStatus) {
-                    ForEach(NetworkStatus.allCases, id: \.self) { value in
-                        Text(value.stringValue)
-                            .tag(value)
-                    }
-                }
-            }
-        }
-    }
-}
-
-struct TodayFinishedView_Previews: PreviewProvider {
-    static var previews: some View {
-        PreviewAllTodayFinished()
-            .environmentObject(SingleStudyAppManager(mockType: .preview))
-    }
+#Preview {
+    TodayFinishedView()
 }

--- a/Sources/BridgeClientUI/SingleStudy/Views/UploadingMessageView.swift
+++ b/Sources/BridgeClientUI/SingleStudy/Views/UploadingMessageView.swift
@@ -1,0 +1,80 @@
+// Created 7/18/24
+// swift-version:5.0
+
+import SwiftUI
+import BridgeClientExtension
+
+/// A general purpose implementation of the header view when there are no assessments currently available
+/// that does not directly tie to the backing view models.
+struct UploadingMessageView : View {
+    @Binding var networkStatus: NetworkStatus
+    let isNextSessionSoon: Bool
+    
+    var body: some View {
+        VStack(alignment: .center, spacing: 24) {
+            if networkStatus.contains(.notConnected) {
+                Image(systemName: "wifi.exclamationmark")
+                    .scaleEffect(x: 1.5, y: 1.5, anchor: .center)
+                    .foregroundColor(.errorRed)
+            } else {
+                progressSpinner()
+            }
+            uploadingMessageText()
+                .font(.italicLatoFont(22))
+        }
+        .padding()
+    }
+    
+    @ViewBuilder
+    func progressSpinner() -> some View {
+        if #available(iOS 15.0, *) {
+            ProgressView()
+                .tint(.accentColor)
+                .scaleEffect(x: 1.5, y: 1.5, anchor: .center)
+        } else {
+            ProgressView()
+        }
+    }
+    
+    @ViewBuilder
+    func uploadingMessageText() -> some View {
+        switch networkStatus {
+        case .cellularDenied:
+            Text("Connect to WiFi or turn on cellular data in your phone's \"Settings\" to allow the app to upload your results.", bundle: .module)
+        case .notConnected:
+            Text("Please connect to the internet to upload your results.", bundle: .module)
+        default:
+            if isNextSessionSoon {
+                Text("Your results are uploading...", bundle: .module)
+            } else {
+                Text("Your results are uploading. Please wait to close the app.", bundle: .module)
+            }
+        }
+    }
+}
+
+// Used to allow previewing the UploadingMessageView.
+fileprivate struct PreviewUploadingMessageView : View {
+    @State var networkStatus: NetworkStatus = .notConnected
+    @State var isNextSessionSoon: Bool = true
+    
+    var body: some View {
+        VStack {
+            UploadingMessageView(networkStatus: $networkStatus, isNextSessionSoon: isNextSessionSoon)
+            Spacer()
+            Form {
+                Toggle("isNextSessionSoon", isOn: $isNextSessionSoon)
+                Picker("Network Connection", selection: $networkStatus) {
+                    ForEach(NetworkStatus.allCases, id: \.self) { value in
+                        Text(value.stringValue)
+                            .tag(value)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PreviewUploadingMessageView()
+}


### PR DESCRIPTION
In testing uploading in airplane mode, I recalled that b/c of how schedules are set up for BiAffect, it will never alert the participant that they have pending uploads. This changes that behavior to show the network status whenever there are pending uploads.
