### PR TITLE
Do not register the background process scheduler if running in an app extension

### DIFF
--- a/Sources/BridgeClientExtension/File Uploading/BackgroundNetworkManager.swift
+++ b/Sources/BridgeClientExtension/File Uploading/BackgroundNetworkManager.swift
@@ -55,16 +55,7 @@ class BackgroundNetworkManager: NSObject, URLSessionBackgroundDelegate, BridgeUR
     var restoredSessions = [String : any BridgeURLSession]()
     
     func isRunningInAppExtension() -> Bool {
-        // "An app extension target’s Info.plist file identifies the extension point and may specify some details
-        // about your extension. At a minimum, the file includes the NSExtension key and a dictionary of keys and
-        // values that the extension point specifies."
-        // (see https://developer.apple.com/library/content/documentation/General/Conceptual/ExtensibilityPG/ExtensionCreation.html)
-        // We also double-check that the Bundle OS Type Code is not APPL, just to be sure they haven't for some
-        // reason added that key to their app's infoDict.
-        guard let infoDict = Bundle.main.infoDictionary,
-              let packageType = infoDict["CFBundlePackageType"] as? String
-            else { return false }
-        return (packageType != "APPL") && infoDict["NSExtension"] != nil
+        AppUtils.isRunningInAppExtension
     }
     
     /// For encoding objects to be passed to Bridge.

--- a/Sources/BridgeClientExtension/File Uploading/BackgroundProcessSyncManager.swift
+++ b/Sources/BridgeClientExtension/File Uploading/BackgroundProcessSyncManager.swift
@@ -46,8 +46,8 @@ actor BackgroundProcessSyncManager {
     /// background.
     @MainActor
     func onLaunch(backgroundProcessId: String?) {
-        // Register the background process
-        if let backgroundProcessId = backgroundProcessId {
+        // Register the background process, but only if this isn't running in an app extension.
+        if let backgroundProcessId = backgroundProcessId, !AppUtils.isRunningInAppExtension {
             registerBackgroundTasks(backgroundProcessId)
         }
         setupAppListeners()

--- a/Sources/BridgeClientExtension/Model/PlatformConfigImpl.swift
+++ b/Sources/BridgeClientExtension/Model/PlatformConfigImpl.swift
@@ -69,6 +69,21 @@ extension IOSBridgeConfig {
     }
 }
 
+final class AppUtils {
+    static var isRunningInAppExtension: Bool {
+        // "An app extension target’s Info.plist file identifies the extension point and may specify some details
+        // about your extension. At a minimum, the file includes the NSExtension key and a dictionary of keys and
+        // values that the extension point specifies."
+        // (see https://developer.apple.com/library/content/documentation/General/Conceptual/ExtensibilityPG/ExtensionCreation.html)
+        // We also double-check that the Bundle OS Type Code is not APPL, just to be sure they haven't for some
+        // reason added that key to their app's infoDict.
+        guard let infoDict = Bundle.main.infoDictionary,
+              let packageType = infoDict["CFBundlePackageType"] as? String
+            else { return false }
+        return (packageType != "APPL") && infoDict["NSExtension"] != nil
+    }
+}
+
 extension Bundle {
     /// The localized name of this application.
     /// This method looks at the plist for the main bundle and returns the most


### PR DESCRIPTION
This explicitly checks to see if the uploading is started from an app extension and does not trigger a background process to upload once network connectivity is available if that is the case.