### PR TITLE
Only show uploading message if not connected or nothing currently available

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
         .target(name: "BridgeClientExtension",
                 dependencies: [
                     "BridgeClient",
+                    "BridgeExceptionHandler",
                     .product(name: "BridgeArchiver", package: "BridgeArchiver-Swift"),
                     .product(name: "JsonModel", package: "JsonModel-Swift"),
                 ]),
@@ -69,5 +70,10 @@ let package = Package(
                         "BridgeClient",
                         "BridgeClientUI",
                     ]),
+        
+        // Changes exceptions into errors so that the app doesn't crash. This is pulled into a
+        // separate module b/c packages can have either Swift or Obj-c.
+        .target(name: "BridgeExceptionHandler",
+                dependencies: []),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,7 @@ let package = Package(
     name: "BridgeClient",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v14),
+        .iOS(.v16),
         .macOS(.v11),
     ],
     products: [

--- a/Sources/BridgeClientExtension/File Uploading/UploadManager.swift
+++ b/Sources/BridgeClientExtension/File Uploading/UploadManager.swift
@@ -231,6 +231,11 @@ class UploadManager : NSObject, BridgeURLSessionHandler, BackgroundProcessSyncDe
     
     private func startS3Upload(_ uploadSession: S3UploadSession) {
         let fileURL = sandboxFileManager.fileURL(of: uploadSession.filePath)
+        // Belt-and-suspenders: Check that the file exists - this will log an error in the cleanup.
+        guard sandboxFileManager.fileExists(at: fileURL) else {
+            handleUnrecoverableFailure(filePath: uploadSession.filePath)
+            return
+        }
         let taskIdentifier = urlUploadTaskIdentifier(filePath: uploadSession.filePath, uploadSessionId: uploadSession.uploadSessionId)
         backgroundNetworkManager.uploadFile(fileURL,
                                             httpHeaders: uploadSession.requestHeaders,

--- a/Sources/BridgeClientUI/SingleStudy/View Models/TodayTimelineViewModel.swift
+++ b/Sources/BridgeClientUI/SingleStudy/View Models/TodayTimelineViewModel.swift
@@ -30,6 +30,8 @@ open class AbstractTodayTimelineViewModel : NSObject, ObservableObject, Schedule
     @Published open var isLoading: Bool = true
     /// Is the next session soon?
     @Published open var isNextSessionSoon: Bool = false
+    /// Is there a session available now?
+    @Published open var hasSessionAvailableNow: Bool = false
     
     /// A flag that can be used to set whether or not a view is presenting the assessment. How the assessment is
     /// presented is up to the views built specifically for a given application.
@@ -56,6 +58,7 @@ open class AbstractTodayTimelineViewModel : NSObject, ObservableObject, Schedule
                 return existingSession
             }
             let sessions = filterSessions(newSessions)
+            self.hasSessionAvailableNow = sessions.contains(where: { $0.state == .availableNow })
             let upNext = sessions.first(where: { $0.state == .upNext })
             self.isNextSessionSoon = upNext?.window.startDateTime.isWithinDays(7) ?? false
             self.sessions = sessions

--- a/Sources/BridgeClientUI/SingleStudy/Views/TodayView.swift
+++ b/Sources/BridgeClientUI/SingleStudy/Views/TodayView.swift
@@ -54,8 +54,11 @@ public struct GenericTodayView : View {
     
     public var body: some View {
         GenericTodayWrapperView(viewModel: viewModel, isUploading: $bridgeManager.isUploading) {
-            UploadingMessageView(networkStatus: $bridgeManager.networkStatus,
-                                 isNextSessionSoon: viewModel.isNextSessionSoon)
+            UploadingMessageView(
+                networkStatus: $bridgeManager.networkStatus,
+                isNextSessionSoon: viewModel.isNextSessionSoon,
+                hasSessionAvailableNow: viewModel.hasSessionAvailableNow
+            )
         }
         .onAppear {
             viewModel.onAppear(bridgeManager: bridgeManager, previewSchedules: previewSchedules)

--- a/Sources/BridgeClientUI/SingleStudy/Views/UploadingMessageView.swift
+++ b/Sources/BridgeClientUI/SingleStudy/Views/UploadingMessageView.swift
@@ -9,8 +9,18 @@ import BridgeClientExtension
 struct UploadingMessageView : View {
     @Binding var networkStatus: NetworkStatus
     let isNextSessionSoon: Bool
+    let hasSessionAvailableNow: Bool
     
     var body: some View {
+        if networkStatus.contains(.notConnected) || !hasSessionAvailableNow {
+            uploadingView()
+        } else {
+            EmptyView()
+        }
+    }
+        
+    @ViewBuilder
+    func uploadingView() -> some View {
         VStack(alignment: .center, spacing: 24) {
             if networkStatus.contains(.notConnected) {
                 Image(systemName: "wifi.exclamationmark")
@@ -20,7 +30,7 @@ struct UploadingMessageView : View {
                 progressSpinner()
             }
             uploadingMessageText()
-                .font(.italicLatoFont(22))
+                .italic()
         }
         .padding()
     }
@@ -44,7 +54,7 @@ struct UploadingMessageView : View {
         case .notConnected:
             Text("Please connect to the internet to upload your results.", bundle: .module)
         default:
-            if isNextSessionSoon {
+            if isNextSessionSoon || hasSessionAvailableNow {
                 Text("Your results are uploading...", bundle: .module)
             } else {
                 Text("Your results are uploading. Please wait to close the app.", bundle: .module)
@@ -57,13 +67,19 @@ struct UploadingMessageView : View {
 fileprivate struct PreviewUploadingMessageView : View {
     @State var networkStatus: NetworkStatus = .notConnected
     @State var isNextSessionSoon: Bool = true
+    @State var hasSessionAvailableNow: Bool = false
     
     var body: some View {
         VStack {
-            UploadingMessageView(networkStatus: $networkStatus, isNextSessionSoon: isNextSessionSoon)
+            UploadingMessageView(
+                networkStatus: $networkStatus,
+                isNextSessionSoon: isNextSessionSoon,
+                hasSessionAvailableNow: hasSessionAvailableNow
+            )
             Spacer()
             Form {
                 Toggle("isNextSessionSoon", isOn: $isNextSessionSoon)
+                Toggle("hasSessionAvailableNow", isOn: $hasSessionAvailableNow)
                 Picker("Network Connection", selection: $networkStatus) {
                     ForEach(NetworkStatus.allCases, id: \.self) { value in
                         Text(value.stringValue)

--- a/Sources/BridgeExceptionHandler/BBCExceptionHandler.m
+++ b/Sources/BridgeExceptionHandler/BBCExceptionHandler.m
@@ -1,0 +1,34 @@
+//
+//  BBCExceptionHandler.m
+
+#import "include/BBCExceptionHandler.h"
+@import Foundation;
+
+@implementation BBCExceptionHandler
+
++ (BOOL)tryBlock:(void (^)(void))tryBlock error:(NSError **)error {
+    
+    @try {
+        tryBlock();
+    }
+    @catch (NSException *exception) {
+        if (error) {
+            NSMutableDictionary *userInfo = [exception.userInfo mutableCopy] ?: [NSMutableDictionary new];
+            userInfo[@"NSExceptionName"] = exception.name;
+            *error = [NSError errorWithDomain:@"BBCExceptionHandlerDomain" code:-1 userInfo:userInfo];
+        }
+        return NO;
+    }
+
+    return YES;
+}
+
+@end
+
+@implementation NSError (BBCExceptionHandler)
+
+- (NSExceptionName)exceptionName {
+    return self.userInfo[@"NSExceptionName"];
+}
+
+@end

--- a/Sources/BridgeExceptionHandler/include/BBCExceptionHandler.h
+++ b/Sources/BridgeExceptionHandler/include/BBCExceptionHandler.h
@@ -1,0 +1,27 @@
+//
+//  BBCExceptionHandler.h
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ `ExceptionHandler` is a work around for Swift not supporting exception handling. There are cases
+ (such as out-of-memory) when it is desirable to exit a function gracefully rather than crashing
+ the app. This class allows for writing Swift methods that convert the `NSException` to an
+ `NSError`.
+ */
+NS_SWIFT_NAME(ExceptionHandler)
+@interface BBCExceptionHandler : NSObject
+
++ (BOOL)tryBlock:(void (^)(void))tryBlock error:(NSError * __autoreleasing *)error;
+
+@end
+
+@interface NSError (BBCExceptionHandler)
+
+- (NSExceptionName _Nullable)exceptionName;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/BridgeClientExtensionTests/FileUpload/V2/UploadManagerTests.swift
+++ b/Tests/BridgeClientExtensionTests/FileUpload/V2/UploadManagerTests.swift
@@ -264,6 +264,10 @@ class MockSandboxFileManager : SandboxFileManager {
         baseURL.appendingPathComponent(subdir, isDirectory: true)
     }
     
+    override func fileExists(at url: URL) -> Bool {
+        fileContentLength(url) != nil
+    }
+    
     func setupFakeArchive() -> (URL, AssessmentScheduleInfo, Date) {
         let now = Date()
         let schedule = AssessmentScheduleInfo(


### PR DESCRIPTION
This hides the message letting participants know that they have data uploading if they have assessments currently available.