### PR TITLE
Revert checking for file existence

### DIFF
--- a/Sources/BridgeClientExtension/File Uploading/UploadManager.swift
+++ b/Sources/BridgeClientExtension/File Uploading/UploadManager.swift
@@ -231,11 +231,6 @@ class UploadManager : NSObject, BridgeURLSessionHandler, BackgroundProcessSyncDe
     
     private func startS3Upload(_ uploadSession: S3UploadSession) {
         let fileURL = sandboxFileManager.fileURL(of: uploadSession.filePath)
-        // Belt-and-suspenders: Check that the file exists - this will log an error in the cleanup.
-        guard sandboxFileManager.fileExists(at: fileURL) else {
-            handleUnrecoverableFailure(filePath: uploadSession.filePath)
-            return
-        }
         let taskIdentifier = urlUploadTaskIdentifier(filePath: uploadSession.filePath, uploadSessionId: uploadSession.uploadSessionId)
         backgroundNetworkManager.uploadFile(fileURL,
                                             httpHeaders: uploadSession.requestHeaders,


### PR DESCRIPTION
This was causing uploads to fail. Without this change, the uploads are working (lightly tested).

Note: this is built and tested with Xcode 15.4